### PR TITLE
Adding an option to round up the timestamp seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,25 +73,26 @@ That's it, you're now sending your miner status to InfluxDB.
 Customize the way NBMiner Reporter works by using the following options:
 
 ```bash
-nbreporter [-v] [-b string] [-f number] [--help] [-h string] [-l string] [-n string] [-o string] [-p number] [-r strinumberng] [-s string] [-t string]
+nbreporter [-v] [-b string] [-f number] [-d number] [-h string] [-l string] [-n string] [-o string] [-p number] [-r strinumberng] [-s string] [-t string] [--help]
 ```
 
 Check the options details.
 
-| Short Flag | Long Flag | Description                                     |
-|----|-------------------|-------------------------------------------------|
-| -n | --name=string     | A friendly name for miner. Default: hostname    |
-| -f | --freq=number     | Status check frequency in seconds. Default: 60  |
-| -h | --ihost=string    | InfluxDB Host.  Default: localhost              |
-| -p | --iport=number    | InfluxDB Port. Default: 8086                    |
-| -t | --itoken=string   | InfluxDB Access Token.                          |
-| -l | --iproto=string   | InfluxDB Protocol.  Default: http               |
-| -b | --ibucket=string  | InfluxDB Bucket. Default: miner                 |
-| -o | --iorg=string     | InfluxDB Organization.  Default: miner-org      |
-| -r | --nbport=number   | NBMiner API Port. Default: 8000                 |
-| -s | --nbhost=string   | NBMiner API Host. Default: localhost            |
-| -v |                   | Run in Verbose mode. Default: false             |
-|    | --help            | Show usage options.                             |
+| Short Flag | Long Flag | Description                                          |
+|----|-------------------|------------------------------------------------------|
+| -n | --name=string     | A friendly name for miner. Default: hostname         |
+| -f | --freq=number     | Status check frequency in seconds. Default: 60       |
+| -d | --round=number    | Round up the status timestamp seconds. Default: 1    |
+| -h | --ihost=string    | InfluxDB Host.  Default: localhost                   |
+| -p | --iport=number    | InfluxDB Port. Default: 8086                         |
+| -t | --itoken=string   | InfluxDB Access Token.                               |
+| -l | --iproto=string   | InfluxDB Protocol.  Default: http                    |
+| -b | --ibucket=string  | InfluxDB Bucket. Default: miner                      |
+| -o | --iorg=string     | InfluxDB Organization.  Default: miner-org           |
+| -r | --nbport=number   | NBMiner API Port. Default: 8000                      |
+| -s | --nbhost=string   | NBMiner API Host. Default: localhost                 |
+| -v |                   | Run in Verbose mode. Default: false                  |
+|    | --help            | Show usage options.                                  |
 
 ## Compatibility
 
@@ -99,7 +100,7 @@ NBMiner Reporter has been tested using the following setups:
 
 | NBM Reporter Ver. | NBMiner Vers. | OS                 | InfluxDB             |
 |-------------------|---------------|--------------------|----------------------|
-| v1.0.X            | 39.7          | Windows 10, HiveOS | 1.8.10, 2.0.x, 2.1.x |
+| v1.0.X            | 39.7 - 40.1   | Windows 10, HiveOS | 1.8.10, 2.0.x, 2.1.x |
 
 ## Contribute
 

--- a/cmd/nbreporter/influxdb_client.go
+++ b/cmd/nbreporter/influxdb_client.go
@@ -16,8 +16,8 @@ import (
 */
 func writeToInflux(status minerStatus) (error) {
 
-	measurement := "miner-device-status"
-	timestamp := time.Now()
+	measurement := "   "
+	timestamp := time.Now().Round(time.Duration(*optCheckFrequencyRound) * time.Second)
 	
     // create new client with default option for server url authenticate by token
 	influxClient := influxdb2.NewClient(fmt.Sprintf("%s://%s:%v", *optInfluxProto, *optInfluxHost, *optInfluxPort), *optInfluxToken)

--- a/cmd/nbreporter/main.go
+++ b/cmd/nbreporter/main.go
@@ -22,6 +22,7 @@ var optInfluxToken = getopt.StringLong("itoken", 't', "", "InfluxDB Access Token
 var optInfluxOrg = getopt.StringLong("iorg", 'o', "miner-org", "InfluxDB Organization. \nDefault: miner-org", "string")
 var optInfluxBucket = getopt.StringLong("ibucket", 'b', "miner", "InfluxDB Bucket. \nDefault: miner", "string")
 var optCheckFrequency = getopt.IntLong("freq", 'f', 60, "Status check frequency in seconds.\nDefault: 60", "number")
+var optCheckFrequencyRound = getopt.IntLong("round", 'd', 1, "Round up the status timestamp seconds.\nDefault: 1", "seconds")
 var optVerbose = getopt.Bool('v', "Run in Verbose mode. \nDefault: false", "string")
 var optHelp = getopt.BoolLong("help", 0, "Show usage options.")
 


### PR DESCRIPTION
# What does this pull request do?
It adds a new flag to round up the seconds in the timestamp reported to make aggregation easier.

# How should it be tested?
Run the NBReporter using the `-d` flag, and check on influxdb that the data points timestamps are getting rounded to the set number of seconds.

# Is related to an Issue?

* Closes #6 

# Any extra info?

If you start the reporter without the flag, and then activate it, you should see something like this while aggregating datapoints. 

![Screen Shot 2021-11-25 at 18 45 04](https://user-images.githubusercontent.com/1449747/143502277-068058de-dd1a-444e-9466-6d78665c3256.png)