### PR TITLE
Adding InfluxDB Setup steps and user and pass flags for Influx 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,35 @@ That's it, you're now sending your miner status to InfluxDB.
 
 That's it, you're now sending your miner status to InfluxDB.
 
+### InfluxDB Setup
+
+You have to be sure that the organization and buckets given to NBReporter already exists in InfluxDB before running the app. Here is an example of how to do it.
+
+#### InfluxDB 1.8.X
+
+If you're using InfluxDB *1.8.X* you just need to create the Database. To do so, simply run the following command on Influx:
+
+```sql
+CREATE DATABASE miner WITH DURATION 7d REPLICATION 1 SHARD DURATION 1h
+```
+
+Here is an example to execute it using `curl`:
+
+```bash
+curl -X POST localhost:8086/query --data-urlencode "q=CREATE DATABASE miner WITH DURATION 7d REPLICATION 1 SHARD DURATION 1h"
+```
+
+Be sure to change `localhost:8086` with the host and port of you InfluxDB server.
+
+#### InfluxDB 2.X
+
+If you're using InfluxDB *2.X* you just need to create the Organization, and the Bucket. To do so, simply use the [influx](https://docs.influxdata.com/influxdb/v2.1/reference/cli/influx/) cli:
+
+```bash
+influx org create --name miner-org
+influx bucket create --name miner --org miner-org --retention 30d
+```
+
 ## CMD Options
 
 Customize the way NBMiner Reporter works by using the following options:
@@ -85,10 +114,12 @@ Check the options details.
 | -d | --round=number    | Round up the status timestamp seconds. Default: 1    |
 | -h | --ihost=string    | InfluxDB Host.  Default: localhost                   |
 | -p | --iport=number    | InfluxDB Port. Default: 8086                         |
-| -t | --itoken=string   | InfluxDB Access Token.                               |
 | -l | --iproto=string   | InfluxDB Protocol.  Default: http                    |
-| -b | --ibucket=string  | InfluxDB Bucket. Default: miner                      |
-| -o | --iorg=string     | InfluxDB Organization.  Default: miner-org           |
+| -t | --token=string    | InfluxDB Access Token.                               |
+| -u | --username=string | InfluxDB Username (For v1.8.x).                      |
+| -w | --password=string | InfluxDB Password (For v1.8.x).                      |
+| -b | --bucket=string   | InfluxDB Bucket. Default: miner                      |
+| -o | --org=string      | InfluxDB Organization.  Default: miner-org           |
 | -r | --nbport=number   | NBMiner API Port. Default: 8000                      |
 | -s | --nbhost=string   | NBMiner API Host. Default: localhost                 |
 | -v |                   | Run in Verbose mode. Default: false                  |

--- a/cmd/nbreporter/influxdb_client.go
+++ b/cmd/nbreporter/influxdb_client.go
@@ -1,14 +1,29 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
     "time"
 
-    "github.com/influxdata/influxdb-client-go/v2"
     log "github.com/sirupsen/logrus"
+    influxdb2 "github.com/influxdata/influxdb-client-go/v2"
+	"github.com/influxdata/influxdb-client-go/v2/domain"
 )
+
+func checkInfluxHealth() (error) {
+	influxClient := influxdb2.NewClient(fmt.Sprintf("%s://%s:%v", *optInfluxProto, *optInfluxHost, *optInfluxPort), token)
+	health, err := influxClient.Health(context.Background())
+	
+	if err != nil {
+		log.Error("Couldn't check InfluxDB Health.")
+		return err
+	} 
+	
+	log.Infof("InfluxDB Version: %s", *domain.HealthCheck(*health).Version)
+	return nil
+}
 
 /*
 	It takes a NBMiner status object, creates an InfluxDB data point
@@ -20,7 +35,7 @@ func writeToInflux(status minerStatus) (error) {
 	timestamp := time.Now().Round(time.Duration(*optCheckFrequencyRound) * time.Second)
 	
     // create new client with default option for server url authenticate by token
-	influxClient := influxdb2.NewClient(fmt.Sprintf("%s://%s:%v", *optInfluxProto, *optInfluxHost, *optInfluxPort), *optInfluxToken)
+	influxClient := influxdb2.NewClient(fmt.Sprintf("%s://%s:%v", *optInfluxProto, *optInfluxHost, *optInfluxPort), token)
     // user blocking write client for writes to desired bucket
     writeAPI := influxClient.WriteAPI(*optInfluxOrg, *optInfluxBucket)
 	// Get errors channel

--- a/cmd/nbreporter/main.go
+++ b/cmd/nbreporter/main.go
@@ -18,14 +18,17 @@ var optNBMinerPort = getopt.IntLong("nbport", 'r', 8000, "NBMiner API Port. \nDe
 var optInfluxProto = getopt.StringLong("iproto", 'l', "http", "InfluxDB Protocol. \nDefault: http", "string")
 var optInfluxHost = getopt.StringLong("ihost", 'h', "localhost", "InfluxDB Host. \nDefault: localhost", "string")
 var optInfluxPort = getopt.IntLong("iport", 'p', 8086, "InfluxDB Port. \nDefault: 8086", "number")
-var optInfluxToken = getopt.StringLong("itoken", 't', "", "InfluxDB Access Token.", "string")
-var optInfluxOrg = getopt.StringLong("iorg", 'o', "miner-org", "InfluxDB Organization. \nDefault: miner-org", "string")
-var optInfluxBucket = getopt.StringLong("ibucket", 'b', "miner", "InfluxDB Bucket. \nDefault: miner", "string")
+var optInfluxToken = getopt.StringLong("token", 't', "", "InfluxDB Access Token.", "string")
+var optInfluxUser = getopt.StringLong("username", 'u', "", "InfluxDB Username (For v1.8.x).", "string")
+var optInfluxPass = getopt.StringLong("password", 'w', "", "InfluxDB Password (For v1.8.x).", "string")
+var optInfluxOrg = getopt.StringLong("org", 'o', "miner-org", "InfluxDB Organization. \nDefault: miner-org", "string")
+var optInfluxBucket = getopt.StringLong("bucket", 'b', "miner", "InfluxDB Bucket. \nDefault: miner", "string")
 var optCheckFrequency = getopt.IntLong("freq", 'f', 60, "Status check frequency in seconds.\nDefault: 60", "number")
-var optCheckFrequencyRound = getopt.IntLong("round", 'd', 1, "Round up the status timestamp seconds.\nDefault: 1", "seconds")
+var optCheckFrequencyRound = getopt.IntLong("round", 'd', 1, "Round up the status timestamp seconds.\nDefault: 1", "number")
 var optVerbose = getopt.Bool('v', "Run in Verbose mode. \nDefault: false", "string")
 var optHelp = getopt.BoolLong("help", 0, "Show usage options.")
 
+var token = ""
 
 func init() {
 	getopt.Parse()
@@ -38,6 +41,17 @@ func init() {
 	if (*optVerbose) {
 		log.SetLevel(log.DebugLevel)
         log.Warn("Log level set to DEBUG")
+	}
+
+	token = *optInfluxToken
+	if *optInfluxUser != "" {
+		log.Debug("Using username as password to authenticate on InfluxDB.")
+		token = fmt.Sprintf("%s:%s",*optInfluxUser, *optInfluxPass)
+	}
+
+	healthError := checkInfluxHealth()
+	if healthError != nil {
+		log.Errorf("Health Error: %s", healthError.Error())
 	}
 }
 /*

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,8 @@ services:
       - "8086:8086"
     environment:
       - INFLUXDB_DB=miner
+      - INFLUXDB_WRITE_USER=miner1
+      - INFLUXDB_WRITE_USER_PASSWORD=miner1-pass
       - DOCKER_INFLUXDB_INIT_MODE=setup
       - DOCKER_INFLUXDB_INIT_USERNAME=miner
       - DOCKER_INFLUXDB_INIT_PASSWORD=minerpass


### PR DESCRIPTION
# What does this pull request do?
It updates the README file by adding the necessary steps to setup InfluxDB to start accepting data from the reporter.

Also, it adds the `username` and `password` flags to authenticate on previous versions of InfluxDB (1.8.X)

# How should it be tested?

To test the InfluxDB Setup simply follow the steps as described in the README file.

To test the new flags, run the reporter with these options: `-u user -w pass -v`. You should see a debug message like the following:

```
WARN[0000] Log level set to DEBUG
DEBU[0000] Using username as password to authenticate on InfluxDB.
INFO[0000] NBMiner Status Reporter Initiated
```

# Is related to an Issue?

* Closes #5
* Closes #11


# Any extra info?
Nope