### PR TITLE
Adding an initial check before starting to wait

### DIFF
--- a/cmd/nbreporter/main.go
+++ b/cmd/nbreporter/main.go
@@ -110,6 +110,7 @@ func main() {
 	// Starting running loop
 	ticker := time.NewTicker(time.Second * time.Duration(*optCheckFrequency))
 	go func() {
+		checkMinerStatus()
 		for range ticker.C {
 			checkMinerStatus()
 		}


### PR DESCRIPTION
# What does this pull request do?
It adds a new call the the miner status check right before starting the waiting loop cycle, this way it doesn't take that long to do the first check

# How should it be tested?
Just build and run, it should send the first status report right away.

# Is related to an Issue?

* Closses #7 


# Any extra info?