### PR TITLE
Restoring measurement name

### DIFF
--- a/cmd/nbreporter/influxdb_client.go
+++ b/cmd/nbreporter/influxdb_client.go
@@ -31,7 +31,7 @@ func checkInfluxHealth() (error) {
 */
 func writeToInflux(status minerStatus, ping int) (error) {
 
-	measurement := "   "
+	measurement := "miner-device-status"
 	timestamp := time.Now().Round(time.Duration(*optCheckFrequencyRound) * time.Second)
 	
     // create new client with default option for server url authenticate by token


### PR DESCRIPTION
# What does this pull request do?
It fixes the missing measurement name, a bug introduced in 1.1.0

# How should it be tested?
Run the reporter and check the base measurement is called `miner-device-status`.

# Is related to an Issue?

* Closses #20 


# Any extra info?