### PR TITLE
Adding cache to reduce lost data points

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Check the options details.
 | -o | --org=string      | InfluxDB Organization.  Default: miner-org           |
 | -r | --nbport=number   | NBMiner API Port. Default: 8000                      |
 | -s | --nbhost=string   | NBMiner API Host. Default: localhost                 |
+| -c | --cache=number    | Cache size. Set to 0 to disable Cache. Default: 60   |
 | -v |                   | Run in Verbose mode. Default: false                  |
 |    | --help            | Show usage options.                                  |
 

--- a/cmd/nbreporter/main.go
+++ b/cmd/nbreporter/main.go
@@ -9,6 +9,7 @@ import (
 
     log "github.com/sirupsen/logrus"
 	getopt "github.com/pborman/getopt"
+	cache "github.com/hashicorp/golang-lru"
 )
 
 var hostname, _ = os.Hostname()
@@ -25,10 +26,18 @@ var optInfluxOrg = getopt.StringLong("org", 'o', "miner-org", "InfluxDB Organiza
 var optInfluxBucket = getopt.StringLong("bucket", 'b', "miner", "InfluxDB Bucket. \nDefault: miner", "string")
 var optCheckFrequency = getopt.IntLong("freq", 'f', 60, "Status check frequency in seconds.\nDefault: 60", "number")
 var optCheckFrequencyRound = getopt.IntLong("round", 'd', 1, "Round up the status timestamp seconds.\nDefault: 1", "number")
+var optCache = getopt.IntLong("cache", 'c', 60, "Cache size. Set to 0 to disable Cache.\nDefault: 60", "number")
 var optVerbose = getopt.Bool('v', "Run in Verbose mode. \nDefault: false", "string")
 var optHelp = getopt.BoolLong("help", 0, "Show usage options.")
 
 var token = ""
+
+var localCache *cache.Cache
+
+type cacheItem struct {
+	Status minerStatus
+	Ping int
+}
 
 /*
 	A siries of setup actions to run just before the main login gets executed
@@ -60,17 +69,19 @@ func init() {
 	if healthError != nil {
 		log.Errorf("Health Error: %s", healthError.Error())
 	}
+	if *optCache > 0 {
+		localCache, _ = cache.New(*optCache)
+	}
 }
 /*
-	This is the process main logic
 	It does a GET request to NBMiner status endpoint, then parses the response body Json to a Struct object
-	and finally it sends its data to InfluxDB
+	and finally it adds it to the local cache, or, if cache is dissabled, it sends the data to InfluxDB
 
 	If anything goes wrong, it's raise an error on the console output, but the process won't stop.
 	This is meant to be like this so it can overcome an internet connection issue, or a miner reboot.
 */
 func checkMinerStatus() {
-	log.Printf("Checking Status.")
+	log.Printf("Getting status from miner.")
 	// Prepares the ping var
 	ping := 1 // If Miner status request succeeds, the ping value will be 1
 	// Gets the Miner status data from the endpoint.
@@ -90,12 +101,79 @@ func checkMinerStatus() {
 		log.Error(err)
 		ping = 0 // If Miner status parse fails, the ping value is set to 0
 	}
-	// Sends the data to InfluxDB
-	log.Debug("Sending data to InfluxDB")
-	writeToInflux(status, ping)
-	log.Debug("Data sent")
+
+	// Creates the timestamp of the datapoint
+	timestamp := time.Now().Round(time.Duration(*optCheckFrequencyRound) * time.Second)
+
+	// If cache is enable
+	if *optCache > 0 {
+		// Storing data on Local Cache
+		localCache.Add(time.Time(timestamp), cacheItem{status, ping})
+	} else {// If cache is dissable
+		// Sends the data to InfluxDB
+		log.Printf("Sending data point to Influx.")
+		error := writeToInflux(timestamp, status, ping)
+		if error != nil {
+			log.Errorf("Write error: %s\n", error.Error())
+			return
+		}
+	}
+
 }
 
+/*
+	Checks the local cache and if it finds any cache items it'll process them (send its datapoints to InfluxDB)
+	till the cache is empty. 
+	
+	It uses the cache as a FIFO list, so it sends all the datapoint in the order in which they were created.
+
+	If anything goes wrong, it's raise an error on the console output, but the process won't stop.
+	This is meant to be like this so it can overcome an internet connection issue, or a miner reboot.
+*/
+func sendDataToInflux() {
+	log.Printf("Sending data point to Influx.")
+
+	// Starts a for loop to process all the items in the cache
+	for {
+		// Gets the current cache size
+		cacheSize := localCache.Len()
+		log.Debugf("Items left in cache: %d", cacheSize)
+		if (cacheSize < 1) { // If it's empty, returns
+			log.Debug("Local cache is empty.")
+			break
+		}
+		// If there are items stored in cache, we get the oldest first
+		key, value, ok := localCache.GetOldest()
+		timestamp, _ := key.(time.Time) // Data point time
+		datapoint, _ := value.(cacheItem) // Data point and ping
+		
+		if ok {
+			log.Debugf("Got oldest data point queue: %v", timestamp)
+			
+			// Sends the data to InfluxDB
+			log.Debug("Writing on InfluxDB")
+			error := writeToInflux(timestamp,datapoint.Status, datapoint.Ping)
+			if error != nil { // Checking for writing errors
+				log.Errorf("Write error: %s\n", error.Error())
+				return
+			}
+
+			// After sending the data to Influx it removes is from the cache
+			log.Debug("Data sent")
+			removed := localCache.Remove(timestamp)
+			if !removed {
+				log.Errorf("Something odd occurred, couldn't remove %v from local cache.", timestamp)
+				return
+			}
+			log.Debug("Datapoint removed from local cache")
+		} 
+	}
+}
+
+/*
+	A function that will listen for a termination signal to be able to 
+	gracefully close all processes.
+*/
 func waitTerminationSignal() {
     var endWaiter sync.WaitGroup
     var signalChannel chan os.Signal
@@ -112,19 +190,47 @@ func waitTerminationSignal() {
 	endWaiter.Wait()
 }
 
+/*
+	Cleans up the processes and cache before stoping
+*/
+func cleanUp(){
+	if *optCache > 0 {
+		log.Debug("Purging the local cache.")
+		localCache.Purge()
+	}
+}
+
+/*
+	Creates a ticker to run a given function periodically on its own go proc.
+*/
+func scheduleFunction(function func()) *time.Ticker {
+	// Creating the ticker
+	ticker := time.NewTicker(time.Second * time.Duration(*optCheckFrequency))
+	
+	// Running initial Check
+	function()
+
+	// Creating go proc to run the function loop
+    go func() {
+        for range ticker.C {
+            function()
+        }
+    }()
+
+    return ticker
+}
+
 func main() {
     log.Printf("NBMiner Status Reporter Initiated")
     log.Printf("Using Friendly Name: %s", *optFriendlyName)
 
-	// Starting running loop
-	ticker := time.NewTicker(time.Second * time.Duration(*optCheckFrequency))
-	go func() {
-		checkMinerStatus()
-		for range ticker.C {
-			checkMinerStatus()
-		}
-	}()
+	// Starting running loops
+	scheduleFunction(checkMinerStatus)
+	if *optCache > 0 {
+		scheduleFunction(sendDataToInflux)
+	}
 
 	waitTerminationSignal()
 	log.Printf("Termination Signal Detected.")
+	cleanUp()
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/deepmap/oapi-codegen v1.8.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/influxdata/influxdb-client-go/v2 v2.5.1 // indirect
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect
 	github.com/pborman/getopt v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219/go.mod h1:/X8TswGSh1pIozq4ZwCfxS0WA5JGXguxk94ar/4c87Y=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/influxdata/influxdb-client-go/v2 v2.5.1 h1:ytMbX2YeupSsec1Exp3zALTjvfhXkvxcyV6nOXkjG3s=
 github.com/influxdata/influxdb-client-go/v2 v2.5.1/go.mod h1:Y/0W1+TZir7ypoQZYd2IrnVOKB3Tq6oegAQeSVN/+EU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=


### PR DESCRIPTION
# What does this pull request do?
It adds a local memory cache to store datapoints from status checks so if influx write fails it'll retry till get all the points there. This will significantly reduce the number of lost points.

# How should it be tested?


# Is related to an Issue?

* Closses #8 
* 
# Any extra info?